### PR TITLE
Contrast Enhancement

### DIFF
--- a/src/flickerprint/common/configuration.py
+++ b/src/flickerprint/common/configuration.py
@@ -43,6 +43,7 @@ SCHEMA = yaml.Map(
                 "tracking_threshold": yaml.Float(),
                 "granule_images": yaml.Bool(),
                 "use_fft": yaml.Bool(),
+                "gamma_adjust": yaml.Float()
             }
         ),
         "spectrum_fitting": yaml.Map(

--- a/src/flickerprint/common/defaults.yaml
+++ b/src/flickerprint/common/defaults.yaml
@@ -83,6 +83,13 @@ image_processing:
   ##   faster than the naive approach, with no change in accuracy.
   use_fft: False
 
+  ## Gamma Adjustment
+  ##   A gamma adjustment >1 may help improve contrast , which can be useful for locating dim
+  ##   granules. The default value of 0.0 will disable this.  We note this this will only affect the
+  ##   granule detection step, the detailed boundary detection used to get the fluctuation spectrum
+  ##   will remain unchanged.
+  gamma_adjust: 0.0
+
 spectrum_fitting:
   ## Experimental spectrum used to fit the theoretical model
   ##   direct: Use the magnitude squared directly

--- a/src/flickerprint/common/frame_gen.py
+++ b/src/flickerprint/common/frame_gen.py
@@ -67,7 +67,8 @@ MicroscopeFrame
 import datetime
 import enum
 import xml.etree.ElementTree as ET
-from dataclasses import dataclass
+from typing import Optional
+from dataclasses import dataclass, field
 from functools import wraps
 from pathlib import Path
 import warnings
@@ -105,6 +106,7 @@ class MicroscopeFrame:
     pixel_size: float = 1.0
     actual_pixel_size: bool = True
     actual_timestamp: bool = False
+    enhanced_image: Optional[np.ndarray] = field(init=False, default=None)
 
     @property
     def summaryRow(self):

--- a/src/flickerprint/common/granule_locator.py
+++ b/src/flickerprint/common/granule_locator.py
@@ -193,7 +193,11 @@ class GranuleDetector:
         method = config("image_processing","method")
 
         if (method == "gradient"):
-            self.processed_image = self.frame.im_data
+            if self.frame.enhanced_image is not None:
+                self.processed_image = self.frame.enhanced_image
+            else:
+                self.processed_image = self.frame.im_data
+
         elif (method == "intensity"):
             self.processed_image = _process_vesicles(self.frame.im_data)
         else:

--- a/src/flickerprint/common/granule_locator_fft.py
+++ b/src/flickerprint/common/granule_locator_fft.py
@@ -52,9 +52,12 @@ class GranuleDetectorFFT(gl.GranuleDetector):
 
         threshold = float(config("image_processing", "granule_minimum_intensity"))
         method = config("image_processing", "method")
-
         if method == "gradient":
-            self.processed_image = self.frame.im_data
+            if self.frame.enhanced_image is not None:
+                self.processed_image = self.frame.enhanced_image
+            else:
+                self.processed_image = self.frame.im_data
+
         elif method == "intensity":
             self.processed_image = gl._process_vesicles(self.frame.im_data)
         else:

--- a/src/flickerprint/workflow/process_image.py
+++ b/src/flickerprint/workflow/process_image.py
@@ -290,6 +290,14 @@ def process_single_image(
 
         if bool(strtobool(config("image_processing", "granule_images"))):
             plot_frame = frame_num % 100 == 0
+
+            figure_dir = output_dir / "tracking"
+            figure_dir.mkdir(exist_ok=True)
+            detection_dir = figure_dir / "detection"
+            detection_dir.mkdir(exist_ok=True)
+
+            outline_dir = figure_dir / "outline"
+            outline_dir.mkdir(exist_ok=True)
         else:
             plot_frame = False
 
@@ -315,13 +323,6 @@ def process_single_image(
             else:
                 continue
 
-        figure_dir = output_dir / "tracking"
-        figure_dir.mkdir(exist_ok=True)
-        detection_dir = figure_dir / "detection"
-        detection_dir.mkdir(exist_ok=True)
-
-        outline_dir = figure_dir / "outline"
-        outline_dir.mkdir(exist_ok=True)
 
         # Show the detected granules in the image
         if plot_frame:
@@ -379,11 +380,12 @@ def process_single_image(
     fourier_frames_pd = pd.concat(fourier_frames, ignore_index=True)
     # fourier_table = consolidate_fourier_terms(fourier_frames_pd)
 
-    # Save a .csv file for debugging
-    save_name = f"fourier/{input_image.stem}"
+    fourier_dir = output_dir / "fourier"
+    fourier_dir.mkdir(exist_ok=True)
+    save_name = input_image.stem
     if max_frame is not None:
         save_name += "--DEBUG"
-    save_path = output_dir / (save_name + ".h5")
+    save_path = fourier_dir / f"{save_name}.h5"
 
     # Save a HDF5 file for better long-term storage with metadata
     frame_data = {

--- a/src/flickerprint/workflow/process_image.py
+++ b/src/flickerprint/workflow/process_image.py
@@ -59,6 +59,7 @@ import warnings
 import multiprocessing as mp
 from time import sleep
 from more_itertools import peekable
+from skimage import exposure
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -279,6 +280,8 @@ def process_single_image(
     disable_bar = True if quiet else None
     process_bar = tqdm.tqdm(enumerate(image_frames), disable=disable_bar, position=_pbar_pos, unit="frame", desc=f"#{_pbar_pos+1}")
 
+    gamma = float(config("image_processing", "gamma_adjust"))
+
     for frame_num, frame in process_bar:
         # Update the progress bar to account for the number of frames
         if frame_num == 0 and not quiet:
@@ -296,6 +299,8 @@ def process_single_image(
         # later.
         plot_granules = plot_frame
 
+        if gamma is not None and gamma > 0.0:
+            frame.enhanced_image = exposure.adjust_gamma(frame.im_data, 1.0 / gamma)
         detector = detector_function(frame)
 
         # Detect the granules within the frame


### PR DESCRIPTION
This adds gamma_adjust contrast enhancements to the configuration file.

Adds an optional "enhanced_image" property to the granule detectors which is used to label the granule if present. This is not used in the boundary detection for the spectrum.

Default behaivour is unchanged.

Also cleans up some of the mkdir behaviour, including for the fourier terms to stop crashes at the end if this isn't present. 