### PR TITLE
Add main file

### DIFF
--- a/src/flickerprint/__main__.py
+++ b/src/flickerprint/__main__.py
@@ -1,3 +1,3 @@
 from flickerprint.workflow import manager
 
-manager.run()
+manager.main()

--- a/src/flickerprint/__main__.py
+++ b/src/flickerprint/__main__.py
@@ -1,0 +1,3 @@
+from flickerprint.workflow import manager
+
+manager.run()


### PR DESCRIPTION
Adds a `__main__.py ` file so that we can run the manager with `python -m flickerprint`

We use `manger.main()` as the entry point which seems like a sensible?